### PR TITLE
MemorySplit: added more info about choice consequence

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -151,10 +151,10 @@ do_memory_split() {
   if ! mountpoint -q /boot; then
     return 1
   fi
-  MEMSPLIT=$(whiptail --menu "Set memory split" 20 60 10 \
-    "224" "224MiB for ARM, 32MiB for VideoCore" \
-    "192" "192MiB for ARM, 64MiB for VideoCore" \
-    "128" "128MiB for ARM, 128MiB for VideoCore" \
+  MEMSPLIT=$(whiptail --menu "Set memory split" 20 78 10 \
+    "224" "224MiB for ARM, 32MiB for VideoCore (No video, No 3D)" \
+    "192" "192MiB for ARM, 64MiB for VideoCore (Video, Simple 3D)" \
+    "128" "128MiB for ARM, 128MiB for VideoCore (Video, Advanced 3D)" \
     3>&1 1>&2 2>&3)
   if [ $? -eq 0 ]; then
     cp -a /boot/arm${MEMSPLIT}_start.elf /boot/start.elf


### PR DESCRIPTION
If the memory split 224/32 is selected, opengl and video demo will fail with a pretty un-user friendly message. This patch adds more information about the choices consequences taken from the forum (http://www.raspberrypi.org/phpBB3/viewtopic.php?f=2&t=5727#p76591).
