### PR TITLE
Added 240/16 memory split and current memory split is displayed.

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -151,7 +151,18 @@ do_memory_split() {
   if ! mountpoint -q /boot; then
     return 1
   fi
-  MEMSPLIT=$(whiptail --menu "Set memory split" 20 60 10 \
+  local CURRENT_MEMSPLIT AVAILABLE_SPLITS
+  AVAILABLE_SPLITS="128 192 224 240"
+  CURRENT_MEMSPLIT=$(
+    for SPLIT in $AVAILABLE_SPLITS;do
+      if cmp /boot/arm${SPLIT}_start.elf /boot/start.elf >/dev/null 2>&1;then
+        echo $SPLIT
+        exit 0
+      fi
+    done
+    )
+    MEMSPLIT=$(whiptail --menu "Set memory split.\nCurrent: ${CURRENT_MEMSPLIT}MiB for ARM, $((256 - $CURRENT_MEMSPLIT))MiB for VideoCore" 20 60 10 \
+    "240" "240MiB for ARM, 16MiB for VideoCore" \
     "224" "224MiB for ARM, 32MiB for VideoCore" \
     "192" "192MiB for ARM, 64MiB for VideoCore" \
     "128" "128MiB for ARM, 128MiB for VideoCore" \


### PR DESCRIPTION
Added 240/16 memory split option - this will allow more memory for headless Raspberry Pi.
The current memory split is displayed in the menu.
