### PR TITLE
Adds the ability to set a unique hostname

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -155,6 +155,24 @@ do_change_timezone() {
   dpkg-reconfigure tzdata
 }
 
+do_change_hostname() {
+  whiptail --msgbox "\
+Please note: RFCs mandate that a hostname's labels \
+may contain only the ASCII letters 'a' through 'z' (case-insensitive), 
+the digits '0' through '9', and the hyphen.
+Hostname labels cannot begin or end with a hyphen. 
+No other symbols, punctuation characters, or blank spaces are permitted.\
+" 20 70 1
+
+  CURRENT_HOSTNAME=`cat /etc/hostname | tr -d " \t\n\r"`
+  NEW_HOSTNAME=$(whiptail --inputbox "Please enter a hostname" 20 60 "$CURRENT_HOSTNAME" 3>&1 1>&2 2>&3)
+  if [ $? -eq 0 ]; then
+    echo $NEW_HOSTNAME > /etc/hostname
+    sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$NEW_HOSTNAME/g" /etc/hosts
+    ASK_TO_REBOOT=1
+  fi
+}
+
 do_memory_split() {
   if [ -e /boot/start_cd.elf ]; then
     # New-style memory split setting
@@ -415,6 +433,7 @@ while true; do
     "change_pass" "Change password for 'pi' user" \
     "change_locale" "Set locale" \
     "change_timezone" "Set timezone" \
+    "change_hostname" "Set hostname" \
     "memory_split" "Change memory split" \
     "overclock" "Configure overclocking" \
     "ssh" "Enable or disable ssh server" \


### PR DESCRIPTION
Hi Alex,

**TL;DR This pull request adds the ability to set a unique hostname during initial set-up.**

This will be a huge help in classroom and hack space environments where many new images are on the same LAN at once. We are finding that users are arriving with their Pi setup but with the default hostname, and without any idea that changing it is a good idea in a group environment. this pull request should help ease the pain at group events that involve beginners/students.

Without a monitor, it's hard work locating your freshly configured RPi on the network for SSH access when they all have the same name... many users want to remote in with a laptop. 

Alternatives such as the serial console to find your IP are a bit overwhelming for beginners. 
As is mounting the SD on a laptop and hunting about in the fs

I have tested this on my Model B and hope you see fit to include this contribution. 

Please let me know if you need me to modify anything. 

Kind regards,
Andrew Stone. 
