### PR TITLE
Added additional command line batch options

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -320,7 +320,13 @@ do_overclock() {
         return 1
         ;;
     esac
-    whiptail --msgbox "Set overclock to preset $OVERCLOCK" 20 60 2
+
+    if [[ $INTERACTIVE -ne False ]] ; then 
+        whiptail --msgbox "Set overclock to preset $OVERCLOCK" 20 60 2
+    else
+        echo "Set overclock to preset $OVERCLOCK"
+    fi
+
     ASK_TO_REBOOT=1
 }
 
@@ -504,18 +510,21 @@ for i in $*
 do
   case $i in
   --hostname=*)
+    INTERACTIVE=False
     HOSTNAME=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
     do_change_hostname $HOSTNAME
     printf "Please reboot\n"
     exit 0
     ;;
   --overclock=*)
+    INTERACTIVE=False
     OVERCLOCK_MODE=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
     do_overclock $OVERCLOCK_MODE
     printf "Please reboot\n"
     exit 0
     ;;
   --memory-split=*)
+    INTERACTIVE=False
     OPT_MEMORY_SPLIT=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
     do_memory_split $OPT_MEMORY_SPLIT
     printf "Please reboot\n"
@@ -613,6 +622,7 @@ do_advanced_menu() {
 #
 # Interactive use loop
 #
+INTERACTIVE=True
 calc_wt_size
 while true; do
   FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Setup Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Finish --ok-button Select \


### PR DESCRIPTION
--hostname=<new_host_name>
--memory-split=<16|32|64|126|256>
--enable-camera|
--disable-camera
--overclock=<None|Modest|Medium|High|Turbo>

NB Some testing done. Further test cases welcome

Following message is displayed. Not sure if benin

$ sudo bash ./raspi-config --overclock=High
update-rc.d: using dependency based boot sequencing
update-rc.d: warning: default start runlevel arguments (2 3 4 5) do not match switch_cpu_governor Default-Start values (S)
update-rc.d: warning: default stop runlevel arguments (0 1 6) do not match switch_cpu_governor Default-Stop values (none)
Set overclock to preset High
