### PR TITLE
Add command line flags to enable/disable camera

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -865,6 +865,16 @@ do
     do_apply_os_config
     exit $?
     ;;
+  --enable_camera)
+    INTERACTIVE=False
+    set_camera 1
+    exit $?
+    ;;
+  --disable_camera)
+    INTERACTIVE=False
+    set_camera 0
+    exit $?
+    ;;
   *)
     # unknown option
     ;;


### PR DESCRIPTION
I'm automating raspi base image creation and while there are parts of raspi-config that are standard unix and therefore easier to manage the automation of elsewhere,  enabling the camera is very raspi specific. 

It makes sense to keep that logic centralized in raspi-config and adding the command line option makes this usable via automation tools. 
