### PR TITLE
fix to check the existence and the validity of /dev/input/event*

### DIFF
--- a/debian/raspi-config.init
+++ b/debian/raspi-config.init
@@ -9,17 +9,46 @@
 # Description:
 ### END INIT INFO
 
+list_valid_events() {
+  events=
+  for x in /dev/input/event*; do
+    if [ -c "$x" ] && dd if="$x" of=/dev/null count=0 >/dev/null 2>/dev/null; then
+      events="$events $x"
+    fi
+  done
+
+  if [ -n "$events" ]; then
+    echo $events
+    return 0
+  else
+    return 1
+  fi
+}
+
 . /lib/lsb/init-functions
 
 case "$1" in
   start)
-    log_daemon_msg "Checking if shift key is held down"
-    timeout 1 thd --dump /dev/input/event* | grep -q "LEFTSHIFT\|RIGHTSHIFT"
+    EVENTS=$(list_valid_events)
     if [ $? -eq 0 ]; then
-      printf " Yes. Not enabling ondemand scaling governor"
+      log_daemon_msg "Checking if shift key is held down"
+      timeout 1 thd --dump $EVENTS | grep -q "LEFTSHIFT\|RIGHTSHIFT"
+      if [ $? -eq 0 ]; then
+        printf " Yes."
+        true
+      else
+        printf " No."
+        false
+      fi
+    else
+      log_daemon_msg "Keyboard is not connected"
+      false
+    fi
+    if [ $? -eq 0 ]; then
+      printf " Not enabling ondemand scaling governor"
       log_end_msg 0
     else
-      printf " No. Switching to ondemand scaling governor"
+      printf " Switching to ondemand scaling governor"
       SYS_CPUFREQ_GOVERNOR=/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
       if [ -e $SYS_CPUFREQ_GOVERNOR ]; then
         echo "ondemand" > $SYS_CPUFREQ_GOVERNOR


### PR DESCRIPTION
When the raspi-config init script checks whether the shift key is being pushed or not,
these 2 problems may occur:
- If the keyboard is not connected, "/dev/input/event*" points no file. So thd prints "Error opening '/dev/input/event*': No such file or directory".
- If the keyboard had once been connected and is no longer connected, the event device is not valid. So thd prints "Error opening '/dev/input/event0': No such device or address", for example.

So I write a function which checks the existence and the validity of /dev/input/event*.
Please evaluate my codes and merge to your master branch.

Regards.
