### PR TITLE
add systemd service

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: raspi-config
 Section: unknown
 Priority: extra
 Maintainer: Alex Bradbury <asb@asbradbury.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), dh-systemd
 Standards-Version: 3.9.2
 Homepage: https://github.com/asb/raspi-config
 #Vcs-Git: git://git.debian.org/collab-maint/raspi-config.git

--- a/debian/raspi-config.init
+++ b/debian/raspi-config.init
@@ -9,15 +9,10 @@
 # Description:
 ### END INIT INFO
 
-. /lib/lsb/init-functions
-
-case "$1" in
-  start)
-    log_daemon_msg "Checking if shift key is held down"
-    timeout 1 thd --dump /dev/input/event* | grep -q "LEFTSHIFT\|RIGHTSHIFT"
+do_start() {
+    timeout 1 thd --dump /dev/input/event* 2>&1 | grep -q "LEFTSHIFT\|RIGHTSHIFT"
     if [ $? -eq 0 ]; then
       printf " Yes. Not enabling ondemand scaling governor"
-      log_end_msg 0
     else
       printf " No. Switching to ondemand scaling governor"
       SYS_CPUFREQ_GOVERNOR=/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
@@ -27,8 +22,19 @@ case "$1" in
         echo 100000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
         echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
       fi
-      log_end_msg 0
     fi
+}
+
+case "$1" in
+  start)
+    . /lib/lsb/init-functions
+    log_daemon_msg "Checking if shift key is held down"
+    do_start
+    log_end_msg 0
+    ;;
+  systemd-start)
+    echo "Checking if shift key is held down"
+    do_start
     ;;
   *)
     echo "Usage: $0 start" >&2

--- a/debian/raspi-config.service
+++ b/debian/raspi-config.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Switch to ondemand cpu governor (unless shift key is pressed)
+DefaultDependencies=no
+Before=sysinit.target
+After=udev.service mountkernfs.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/etc/init.d/raspi-config systemd-start
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@ --with systemd


### PR DESCRIPTION
The generated unit in `/run/systemd/generator.late/raspi-config.service` is sub-optimal.
Here is a native service that share code with sysv script.

![con](https://cloud.githubusercontent.com/assets/7994192/7550710/6624971c-f66c-11e4-931b-56c7a85cda3a.png)
