### PR TITLE
Create more suitable Raspberry Pi 2 overclock settings.

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -279,13 +279,14 @@ system instability, try a more modest overclock. Hold down
 shift during boot to temporarily disable overclock.
 See http://elinux.org/RPi_Overclocking for more information.\
 " 20 70 1
-  OVERCLOCK=$(whiptail --menu "Chose overclock preset" 20 60 10 \
+  OVERCLOCK=$(whiptail --menu "Choose overclock preset" 20 66 10 \
     "None" "700MHz ARM, 250MHz core, 400MHz SDRAM, 0 overvolt" \
     "Modest" "800MHz ARM, 250MHz core, 400MHz SDRAM, 0 overvolt" \
     "Medium" "900MHz ARM, 250MHz core, 450MHz SDRAM, 2 overvolt" \
     "High" "950MHz ARM, 250MHz core, 450MHz SDRAM, 6 overvolt" \
     "Turbo" "1000MHz ARM, 500MHz core, 600MHz SDRAM, 6 overvolt" \
-    "Pi2" "1000MHz ARM, 500MHz core, 500MHz SDRAM, 2 overvolt" \
+    "Pi2_None" "900MHz ARM, 250MHz core, 450MHz SDRAM, 0 overvolt" \
+    "Pi2_Modest" "1000MHz ARM, 500MHz core, 483MHz SDRAM, 0 overvolt" \
     3>&1 1>&2 2>&3)
   if [ $? -eq 0 ]; then
     case "$OVERCLOCK" in
@@ -304,8 +305,11 @@ See http://elinux.org/RPi_Overclocking for more information.\
       Turbo)
         set_overclock Turbo 1000 500 600 6
         ;;
-      Pi2)
-        set_overclock Pi2 1000 500 500 2
+      Pi2_None)
+        set_overclock Pi2_None 900 250 450 0
+        ;;
+      Pi2_Modest)
+        set_overclock Pi2_Modest 1000 500 483 0
         ;;
       *)
         whiptail --msgbox "Programmer error, unrecognised overclock preset" 20 60 2


### PR DESCRIPTION
First off there is no reset to default, so adding a Pi2_None option to
go back to those.

Second, furhter research(*) has shown that slightly lower settings do
not cause stabilty problems versus the current overclock settings.
Renaming this modest overclock settings due to lack of overvoltage.

(*) http://linuxonflash.blogspot.nl/2015/02/a-look-at-raspberry-
pi-2-performance.html
